### PR TITLE
creado infraestructura para instalar nvm, Node y Mocha en Ubuntu 14.04

### DIFF
--- a/infraestructura.md
+++ b/infraestructura.md
@@ -1,0 +1,7 @@
+# Instalar nvm, Node y Mocha en Ubuntu 14.04
+
+`curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.29.0/install.sh | sudo bash`
+
+`nvm install node`
+
+`npm install mocha`


### PR DESCRIPTION
Espero que sirva así, lo de Chef era más complicado sin contar con un servidor. Son 3 comandos en una terminal y ya está todo funcional.